### PR TITLE
Add expression distribution

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,5 @@
   "tabWidth": 2,
   "semi": true,
   "singleQuote": true,
-  "printWidth": 120
+  "printWidth": 999
 }

--- a/src/distribution.ts
+++ b/src/distribution.ts
@@ -1,0 +1,178 @@
+import { DistributionError } from './errors';
+import { ASTBinOp, ASTDice, ASTLiteral, ASTNode, ASTParenthetical, ASTUnOp } from './parser';
+import { sum } from './util';
+
+const DiceLimits = 101 * 101; //Allow 100d100, but nothing more
+const OperationLimits = 8192;
+
+function id<T>(v: T): T {
+  return v;
+}
+
+export class Distribution {
+  private readonly values: Map<number, number>;
+
+  constructor(values?: Map<number, number> | undefined) {
+    if (!values) {
+      this.values = new Map([[0.0, 1.0]]);
+    } else {
+      this.values = values;
+    }
+  }
+
+  public static uniform(sides: number): Distribution {
+    const map = new Map<number, number>();
+    for (let i = 1; i <= sides; i++) {
+      map.set(i, 1 / sides);
+    }
+    return new Distribution(map);
+  }
+
+  public static fromAST(node: ASTNode): Distribution {
+    if (node instanceof ASTLiteral) {
+      return new Distribution(new Map([[node.value, 1.0]]));
+    }
+
+    if (node instanceof ASTDice) {
+      return calculateDiceDistribution(node);
+    }
+
+    if (node instanceof ASTParenthetical) {
+      return Distribution.fromAST(node.value);
+    }
+
+    if (node instanceof ASTUnOp) {
+      if (node.op === '+') return Distribution.fromAST(node.value);
+      if (node.op === '-') return Distribution.neg(Distribution.fromAST(node.value));
+      throw new DistributionError(`Distribution: unsupported UnOp operator '${node.op}'`);
+    }
+
+    if (node instanceof ASTBinOp) {
+      const left = Distribution.fromAST(node.left);
+      const right = Distribution.fromAST(node.right);
+
+      if (node.op === '+') return Distribution.add(left, right);
+      if (node.op === '-') return Distribution.sub(left, right);
+      if (node.op === '*') return Distribution.mul(left, right);
+      if (node.op === '/') return Distribution.div(left, right);
+      if (node.op === '%') return Distribution.mod(left, right);
+      if (node.op === '//') return Distribution.div(left, right);
+
+      throw new DistributionError(`Distribution: unsupported BinOp operator '${node.op}'`);
+    }
+
+    throw new DistributionError(`Distribution: unsupported node type '${node.constructor.name}'`);
+  }
+
+  public keys(): readonly number[] {
+    return Array.from(this.values.keys());
+  }
+
+  public get(key: number): number {
+    return this.values.get(key) ?? 0;
+  }
+
+  public entries(): [number, number][] {
+    return Array.from(this.values.entries());
+  }
+
+  public mean(mapping: (v: number) => number = id): number {
+    return sum(this.entries().map(([key, value]) => mapping(key) * value));
+  }
+
+  public stddev(): number {
+    // variance = E(X^2) - E(X)^2
+    // stddev = sqrt(variance)
+    const e_x2 = this.mean((v) => v * v);
+    const ex_2 = Math.pow(this.mean(), 2);
+    return Math.sqrt(e_x2 - ex_2);
+  }
+
+  public copy() {
+    return new Distribution(new Map(this.values.entries()));
+  }
+
+  public static combine(a: Distribution, b: Distribution, func: (a: number, b: number) => number): Distribution {
+    const values = new Map<number, number>();
+    for (const [ka, va] of a.values.entries()) {
+      for (const [kb, vb] of a.values.entries()) {
+        const key = func(ka, kb);
+        const value = (values.get(key) ?? 0) + va * vb;
+        values.set(key, value);
+      }
+    }
+
+    return new Distribution(values);
+  }
+
+  public static add(a: Distribution, b: Distribution) {
+    return Distribution.combine(a, b, (a, b) => a + b);
+  }
+
+  public static sub(a: Distribution, b: Distribution) {
+    return Distribution.combine(a, b, (a, b) => a - b);
+  }
+
+  public static mul(a: Distribution, b: Distribution) {
+    return Distribution.combine(a, b, (a, b) => a * b);
+  }
+
+  public static div(a: Distribution, b: Distribution) {
+    return Distribution.combine(a, b, (a, b) => Math.floor(a / b));
+  }
+
+  public static mod(a: Distribution, b: Distribution) {
+    return Distribution.combine(a, b, (a, b) => a % b);
+  }
+
+  public static neg(a: Distribution) {
+    const values: [number, number][] = Array.from(a.values.entries()).map((value) => [-value[0], value[1]]);
+    return new Distribution(new Map(values));
+  }
+
+  public static advantage(a: Distribution) {
+    return Distribution.combine(a, a, Math.max);
+  }
+
+  public static disadvantage(a: Distribution) {
+    return Distribution.combine(a, a, Math.min);
+  }
+}
+
+function uniform(sides: number): Map<number, number> {
+  const map = new Map<number, number>();
+  for (let i = 1; i <= sides; i++) {
+    map.set(i, 1 / sides);
+  }
+  return map;
+}
+
+function calculateDiceDistribution(dice: ASTDice): Distribution {
+  if (dice.operations.length > 0) {
+    return calculateDiceDistribution(dice);
+  }
+
+  if (dice.sides === 0) {
+    throw new DistributionError(`Cannot create a distribution of a dice with zero sides in '${dice.toString()}'!`);
+  }
+
+  if (dice.sides * dice.count > DiceLimits) {
+    throw new DistributionError(`There are too many dice to calculate in '${dice.toString()}'!`);
+  }
+
+  let distribution = new Distribution();
+  for (let i = 0; i < dice.count; i++) {
+    const uniform = Distribution.uniform(dice.sides);
+    distribution = Distribution.add(distribution, uniform);
+  }
+
+  return distribution;
+}
+
+function calculateDiscreteDiceDistribution(dice: ASTDice): Distribution {
+  if (dice.operations.length > OperationLimits) {
+    throw new DistributionError(`There are too many operations to calculate in '${dice.toString()}'!`);
+  }
+
+  throw new DistributionError('calculateDiscreteDiceDistribution not implemented yet');
+}

--- a/src/distribution.ts
+++ b/src/distribution.ts
@@ -150,7 +150,7 @@ export class Distribution {
 
 function calculateDiceDistribution(dice: ASTDice): Distribution {
   if (dice.operations.length > 0) {
-    return calculateDiceDistribution(dice);
+    return calculateDiscreteDiceDistribution(dice);
   }
 
   if (dice.sides === 0) {
@@ -168,4 +168,14 @@ function calculateDiceDistribution(dice: ASTDice): Distribution {
   }
 
   return distribution;
+}
+
+function calculateDiscreteDiceDistribution(dice: ASTDice): Distribution {
+  console.log(Math.pow(dice.sides, dice.count));
+  if (Math.pow(dice.sides, dice.count) > OperationLimits) {
+    throw new DistributionError(`Dice expression with modifiers '${dice.toString()}' is too large to calculate!`);
+  }
+
+  // TODO throw new Error(`calculateDiscreteDiceDistribution not implemented yet!`);
+  return Distribution.uniform(1);
 }

--- a/src/distribution.ts
+++ b/src/distribution.ts
@@ -122,6 +122,11 @@ export class Distribution {
   }
 
   public static div(a: Distribution, b: Distribution) {
+    for (const key of b.keys()) {
+      if (key === 0) {
+        throw new DistributionError('Distribution contains potential divide by zero!');
+      }
+    }
     return Distribution.combine(a, b, (a, b) => Math.floor(a / b));
   }
 

--- a/src/distribution.ts
+++ b/src/distribution.ts
@@ -171,7 +171,6 @@ function calculateDiceDistribution(dice: ASTDice): Distribution {
 }
 
 function calculateDiscreteDiceDistribution(dice: ASTDice): Distribution {
-  console.log(Math.pow(dice.sides, dice.count));
   if (Math.pow(dice.sides, dice.count) > OperationLimits) {
     throw new DistributionError(`Dice expression with modifiers '${dice.toString()}' is too large to calculate!`);
   }

--- a/src/distribution.ts
+++ b/src/distribution.ts
@@ -12,12 +12,8 @@ function id<T>(v: T): T {
 export class Distribution {
   private readonly values: Map<number, number>;
 
-  constructor(values?: Map<number, number> | undefined) {
-    if (!values) {
-      this.values = new Map([[0.0, 1.0]]);
-    } else {
-      this.values = values;
-    }
+  constructor(values: Map<number, number>) {
+    this.values = values;
   }
 
   public static uniform(sides: number): Distribution {
@@ -72,6 +68,14 @@ export class Distribution {
     return this.values.get(key) ?? 0;
   }
 
+  public min(): number {
+    return Math.min(...this.keys());
+  }
+
+  public max(): number {
+    return Math.max(...this.keys());
+  }
+
   public entries(): [number, number][] {
     return Array.from(this.values.entries());
   }
@@ -95,7 +99,7 @@ export class Distribution {
   public static combine(a: Distribution, b: Distribution, func: (a: number, b: number) => number): Distribution {
     const values = new Map<number, number>();
     for (const [ka, va] of a.values.entries()) {
-      for (const [kb, vb] of a.values.entries()) {
+      for (const [kb, vb] of b.values.entries()) {
         const key = func(ka, kb);
         const value = (values.get(key) ?? 0) + va * vb;
         values.set(key, value);
@@ -139,14 +143,6 @@ export class Distribution {
   }
 }
 
-function uniform(sides: number): Map<number, number> {
-  const map = new Map<number, number>();
-  for (let i = 1; i <= sides; i++) {
-    map.set(i, 1 / sides);
-  }
-  return map;
-}
-
 function calculateDiceDistribution(dice: ASTDice): Distribution {
   if (dice.operations.length > 0) {
     return calculateDiceDistribution(dice);
@@ -160,19 +156,11 @@ function calculateDiceDistribution(dice: ASTDice): Distribution {
     throw new DistributionError(`There are too many dice to calculate in '${dice.toString()}'!`);
   }
 
-  let distribution = new Distribution();
+  let distribution = new Distribution(new Map([[0.0, 1.0]]));
   for (let i = 0; i < dice.count; i++) {
     const uniform = Distribution.uniform(dice.sides);
     distribution = Distribution.add(distribution, uniform);
   }
 
   return distribution;
-}
-
-function calculateDiscreteDiceDistribution(dice: ASTDice): Distribution {
-  if (dice.operations.length > OperationLimits) {
-    throw new DistributionError(`There are too many operations to calculate in '${dice.toString()}'!`);
-  }
-
-  throw new DistributionError('calculateDiscreteDiceDistribution not implemented yet');
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,10 +1,3 @@
-export class LexerError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'LexerError';
-  }
-}
-
 export class ParserError extends Error {
   constructor(message: string) {
     super(message);
@@ -23,5 +16,12 @@ export class TooManyRollsError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'TooManyRollsError';
+  }
+}
+
+export class DistributionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DistributionError';
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { Distribution } from './distribution';
 import { ASTNode } from './parser';
 import { Parser } from './parser';
 import { Roller, RolledNode } from './roll';
@@ -5,6 +6,7 @@ import { Roller, RolledNode } from './roll';
 export * from './roll';
 export * from './parser';
 export * from './errors';
+export * from './distribution';
 
 export function parse(expression: string): ASTNode {
   const parser = new Parser();
@@ -15,4 +17,9 @@ export function roll(expression: string): RolledNode {
   const ast = parse(expression);
   const roller = new Roller();
   return roller.roll(ast);
+}
+
+export function distribution(expression: string): Distribution {
+  const ast = parse(expression);
+  return Distribution.fromAST(ast);
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8,7 +8,7 @@ export class Parser {
       const parsed = parse(expression);
       return this.parseNode(parsed);
     } catch {
-      throw new ParserError(`Could not parse expression '${expression}'!`)
+      throw new ParserError(`Could not parse expression '${expression}'!`);
     }
   }
 
@@ -17,7 +17,7 @@ export class Parser {
       return new ASTLiteral(node.value);
     }
     if (node.type === 'Dice') {
-      const operations = node.op.map((op: any) => new DiceOperation(op.op, op.selector));
+      const operations = node.op.map((op: any) => new DiceOperation(op.op, new Selector(op.selector.type, op.selector.value)));
       return new ASTDice(node.expression.count, node.expression.sides, operations);
     }
     if (node.type === 'Parenthetical') {
@@ -132,9 +132,14 @@ export class ASTParenthetical extends ASTNode {
 // Operators
 // ===================================
 
-export interface Selector {
-  type: string | null;
-  value: number;
+export class Selector {
+  public readonly type: string | null;
+  public readonly value: number;
+
+  constructor(type: string | null, value: number) {
+    this.type = type;
+    this.value = value;
+  }
 }
 
 export class DiceOperation {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4,7 +4,12 @@ import { parse } from './grammar';
 
 export class Parser {
   public parse(expression: string): ASTNode {
-    return this.parseNode(parse(expression));
+    try {
+      const parsed = parse(expression);
+      return this.parseNode(parsed);
+    } catch {
+      throw new ParserError(`Could not parse expression '${expression}'!`)
+    }
   }
 
   private parseNode(node: any): ASTNode {

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,3 +7,28 @@ export function sorted<T>(array: T[], compareFn?: (a: T, b: T) => number): T[] {
 export function sum(values: number[]): number {
   return values.reduce((a, b) => a + b, 0);
 }
+
+export function range(min: number, max: number): number[] {
+  const array = [];
+  for (let i = min; i <= max; i++) {
+    array.push(i);
+  }
+  return array;
+}
+
+export function cartesianProduct<T>(arrays: T[][]): T[][] {
+  if (arrays.length === 1) {
+    return arrays[0].map((array) => [array]);
+  }
+
+  const result: T[][] = [];
+  const subarrays = cartesianProduct(arrays.slice(1));
+
+  for (const value of arrays[0]) {
+    for (const subarray of subarrays) {
+      result.push([value, ...subarray]);
+    }
+  }
+
+  return result;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,3 +3,7 @@ export function sorted<T>(array: T[], compareFn?: (a: T, b: T) => number): T[] {
   copy.sort(compareFn);
   return copy;
 }
+
+export function sum(values: number[]): number {
+  return values.reduce((a, b) => a + b, 0);
+}

--- a/tests/distribution.test.ts
+++ b/tests/distribution.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest';
+
+import * as d20 from '../src';
+
+test('test d20', () => {
+  const distribution = d20.distribution('1d20');
+
+    console.log(distribution.keys())
+
+  expect(distribution.min()).toEqual(1);
+  expect(distribution.max()).toEqual(20);
+  expect(distribution.keys().length).toEqual(20);
+
+  for (let i = distribution.min(); i < distribution.max(); i++) {
+    expect(distribution.get(i)).toEqual(0.05);
+  }
+
+  expect(distribution.get(100)).toEqual(0.0);
+});

--- a/tests/distribution.test.ts
+++ b/tests/distribution.test.ts
@@ -68,8 +68,8 @@ test('test limits', () => {
   // The expressions below should within the acceptable limits
 
   d20.distribution('50d50'); // No operators, less than 101*101
-  d20.distribution('4d6kh3'); // Operators, less than 8192 possibilities
+  d20.distribution('4d6mi3'); // Operators, less than 8192 possibilities
 
   expect(() => d20.distribution('400d400')).toThrowError(d20.DistributionError); // No operators, too many dice
-  expect(() => d20.distribution('6d6kh3')).toThrowError(d20.DistributionError); // Operators, too many possibilities
+  expect(() => d20.distribution('6d6mi3')).toThrowError(d20.DistributionError); // Operators, too many possibilities
 });

--- a/tests/distribution.test.ts
+++ b/tests/distribution.test.ts
@@ -35,6 +35,13 @@ test('test limits', () => {
   expect(() => d20.distribution('6d6mi3')).toThrowError(d20.DistributionError); // Operators, too many possibilities
 });
 
+test('test invalid selectors', () => {
+  // These tests should throw errors, because the used selectors are not supported for the operations
+
+  expect(() => d20.distribution('4d20mi<3')).toThrow(d20.DistributionError);
+  expect(() => d20.distribution('4d20mal3')).toThrow(d20.DistributionError);
+});
+
 // ==========================================
 // Test the results of individual expressions
 // ==========================================

--- a/tests/distribution.test.ts
+++ b/tests/distribution.test.ts
@@ -5,8 +5,6 @@ import * as d20 from '../src';
 test('test d20', () => {
   const distribution = d20.distribution('1d20');
 
-    console.log(distribution.keys())
-
   expect(distribution.min()).toEqual(1);
   expect(distribution.max()).toEqual(20);
   expect(distribution.keys().length).toEqual(20);
@@ -16,4 +14,9 @@ test('test d20', () => {
   }
 
   expect(distribution.get(100)).toEqual(0.0);
+});
+
+test('test exceptions', () => {
+  expect(() => d20.distribution('1d6 / 0')).toThrowError(d20.DistributionError); // Divide by zero error
+  expect(() => d20.distribution('1d6 +')).toThrowError(d20.ParserError); // Invalid expression
 });

--- a/tests/distribution.test.ts
+++ b/tests/distribution.test.ts
@@ -16,6 +16,49 @@ test('test d20', () => {
   expect(distribution.get(100)).toEqual(0.0);
 });
 
+test('test complex expression', () => {
+  // Results were verified using anydice
+  const expression = '3d6 + 2 * 1d4 - 4';
+  const probabilities: [number, number][] = [
+    [1, 0.0012],
+    [2, 0.0035],
+    [3, 0.0081],
+    [4, 0.015],
+    [5, 0.0255],
+    [6, 0.0394],
+    [7, 0.0544],
+    [8, 0.0706],
+    [9, 0.0845],
+    [10, 0.0961],
+    [11, 0.1019],
+    [12, 0.1019],
+    [13, 0.0961],
+    [14, 0.0845],
+    [15, 0.0706],
+    [16, 0.0544],
+    [17, 0.0394],
+    [18, 0.0255],
+    [19, 0.015],
+    [20, 0.0081],
+    [21, 0.0035],
+    [22, 0.0012],
+  ];
+  const mean = 11.5;
+  const stddev = 3.71;
+
+  const distribution = d20.distribution(expression);
+
+  expect(distribution.min()).toEqual(1);
+  expect(distribution.max()).toEqual(22);
+
+  for (const [key, value] of probabilities) {
+    expect(distribution.get(key)).toBeCloseTo(value, 4);
+  }
+
+  expect(distribution.mean()).toBeCloseTo(mean, 2);
+  expect(distribution.stddev()).toBeCloseTo(stddev, 2);
+});
+
 test('test exceptions', () => {
   expect(() => d20.distribution('1d6 / 0')).toThrowError(d20.DistributionError); // Divide by zero error
   expect(() => d20.distribution('1d6 +')).toThrowError(d20.ParserError); // Invalid expression

--- a/tests/distribution.test.ts
+++ b/tests/distribution.test.ts
@@ -20,3 +20,13 @@ test('test exceptions', () => {
   expect(() => d20.distribution('1d6 / 0')).toThrowError(d20.DistributionError); // Divide by zero error
   expect(() => d20.distribution('1d6 +')).toThrowError(d20.ParserError); // Invalid expression
 });
+
+test('test limits', () => {
+  // The expressions below should within the acceptable limits
+
+  d20.distribution('50d50'); // No operators, less than 101*101
+  d20.distribution('4d6kh3'); // Operators, less than 8192 possibilities
+
+  expect(() => d20.distribution('400d400')).toThrowError(d20.DistributionError); // No operators, too many dice
+  expect(() => d20.distribution('6d6kh3')).toThrowError(d20.DistributionError); // Operators, too many possibilities
+});


### PR DESCRIPTION
Adds distributions to the library. For dice, only the `mi` and `ma` operators are supported for now. The other operators should be added in the future.

Closes #3 